### PR TITLE
Correction errors for calculate medians

### DIFF
--- a/include/delphioracle/custom_ctime.hpp
+++ b/include/delphioracle/custom_ctime.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <ctime>
+#include <map>
+
+namespace custom_ctime
+{
+    std::map<uint8_t, uint8_t> months =
+    {
+        {0, 31}, {1, 28},  {2, 31},
+        {3, 30}, {4, 31},  {5, 30},
+        {6, 31}, {7, 31},  {8, 30},
+        {9, 31}, {10, 30}, {11, 31},
+    };
+
+    tm* gmtime(const time_t *_Time/*timestamp format*/)
+    {
+        if (_Time == nullptr)
+            return nullptr;
+
+        tm* date = new tm();
+        time_t temp_time = *_Time;
+
+        int32_t timestamp_year = temp_time / 31536000;
+        int32_t count_leap_year = timestamp_year / 4;
+
+        temp_time = temp_time - (count_leap_year * 86400);
+
+        date->tm_year = (temp_time / 31536000) + 70;
+        temp_time = temp_time % 31536000;
+
+        date->tm_yday = (temp_time / 86400);
+        temp_time %= 86400;
+
+        date->tm_hour = temp_time / 3600;
+        temp_time %= 3600;
+
+        date->tm_min = temp_time / 60;
+        temp_time %= 60;
+
+        date->tm_sec = temp_time;
+
+        int32_t days_in_year = date->tm_yday + 1;
+        for (auto i = 0; i != 11; ++i)
+        {
+            const int32_t count_days = months.at(i);
+            if (days_in_year < count_days)
+            {
+                date->tm_mon = i;
+                date->tm_mday = days_in_year;
+                break;
+            }
+
+            days_in_year -= count_days;
+        }
+
+        return date;
+    }
+
+    time_t mktime(struct tm *_Tm)
+    {
+        if (_Tm == nullptr)
+            return 0;
+
+        int32_t count_years_after_timestamp = _Tm->tm_year - 70;
+        int32_t count_leap_year = count_years_after_timestamp / 4;
+
+        time_t timestamp = static_cast<time_t>(count_years_after_timestamp) * 31536000;
+        timestamp += static_cast<time_t>(count_leap_year) * 86400;
+        timestamp += static_cast<time_t>(_Tm->tm_yday) * 86400;
+        timestamp += static_cast<time_t>(_Tm->tm_hour) * 3600;
+        timestamp += static_cast<time_t>(_Tm->tm_min) * 60;
+        timestamp += static_cast<time_t>(_Tm->tm_sec);
+        return timestamp;
+    }
+}

--- a/include/delphioracle/delphioracle.hpp
+++ b/include/delphioracle/delphioracle.hpp
@@ -29,12 +29,13 @@ static const std::string system_str("system");
 
 static const asset one_larimer = asset(1, symbol("TLOS", 4));
 
-enum class median_types : int8_t {
-    none = -1,
+enum class median_types : uint8_t {
     day = 0,
     week = 1,
     month = 2,
     current_week = 4,
+
+    none = 255,
 };
 
 const checksum256 NULL_HASH;
@@ -294,21 +295,21 @@ CONTRACT delphioracle : public eosio::contract {
 
   TABLE medians {
     uint64_t   id;
-    int8_t     type;
-    uint64_t   value;
-    uint64_t   request_count;
-    time_point timestamp;
+    uint8_t    type = get_type(median_types::none);
+    uint64_t   value = 0;
+    uint64_t   request_count = 0;
+    time_point timestamp = NULL_TIME_POINT;
 
     uint64_t primary_key() const { return id; }
     uint64_t by_timestamp() const { return timestamp.elapsed.to_seconds(); }
 
-    static int8_t get_type(median_types type) {
-      return static_cast<int8_t>(type);
+    static uint8_t get_type(median_types type) {
+      return static_cast<uint8_t>(type);
     }
   };
 
   TABLE debug {
-    int64_t days = 0;
+    int32_t days = 0;
   };
   using singleton_debug = eosio::singleton<"debug"_n, debug>;
 
@@ -424,7 +425,7 @@ CONTRACT delphioracle : public eosio::contract {
 private:
   bool _is_active_current_week_cashe = false;
 
-  void make_records_for_medians_table(median_types type, const name& pair, const name& payer);
+  void make_records_for_medians_table(median_types type, const name& pair, const name& payer, const medians& default_median);
   const time_point get_round_up_current_time(median_types type) const;
   bool is_in_time_range(median_types type, const time_point& start_time_range,
     const time_point& time_value, bool is_previous_value = false) const;

--- a/include/delphioracle/delphioracle.hpp
+++ b/include/delphioracle/delphioracle.hpp
@@ -375,6 +375,11 @@ CONTRACT delphioracle : public eosio::contract {
   ACTION initmedians(bool is_active);
   ACTION updtversion();
 
+  ACTION debugadddays(int32_t days);
+  using debugadddays_action = action_wrapper<name("debugadddays"), &delphioracle::debugadddays>;
+  ACTION dabugrstdays();
+  using dabugrstdays_action = action_wrapper<name("dabugrstdays"), &delphioracle::dabugrstdays>;
+
   [[eosio::on_notify("eosio.token::transfer")]]
   void transfer(uint64_t sender, uint64_t receiver) {
     //print("transfer notifier", "\n");
@@ -427,12 +432,8 @@ private:
   void update_medians(const name& owner, const uint64_t value, pairstable::const_iterator pair_itr);
   void update_medians_by_types(median_types type, const name& owner, const name& pair, 
     const time_point& median_timestamp, const uint64_t median_value, const uint64_t median_request_count = 1);
-  //void update_medians_by_types_old(median_types type, const name& owner, const name& pair, 
-  //  const time_point& median_timestamp, const uint64_t median_value, const uint64_t median_request_count = 1);
-  //void update_medians_by_types_new(median_types type, const name& owner, const name& pair, 
-  //  const time_point& median_timestamp, const uint64_t median_value, const uint64_t median_request_count = 1);
-  median_types get_next_type(median_types current_type) const;
   bool is_active_current_week() const;
+  std::vector<median_types> GetUpdateMedians(median_types current_type) const;
 
   //Check if calling account is a qualified oracle
   bool check_oracle(const name owner) {

--- a/include/delphioracle/delphioracle.hpp
+++ b/include/delphioracle/delphioracle.hpp
@@ -308,11 +308,6 @@ CONTRACT delphioracle : public eosio::contract {
     }
   };
 
-  TABLE debug {
-    int32_t days = 0;
-  };
-  using singleton_debug = eosio::singleton<"debug"_n, debug>;
-
   TABLE flagmedians {
     bool is_active = false;
   };
@@ -375,11 +370,6 @@ CONTRACT delphioracle : public eosio::contract {
   ACTION makemedians();
   ACTION initmedians(bool is_active);
   ACTION updtversion();
-
-  ACTION debugadddays(int32_t days);
-  using debugadddays_action = action_wrapper<name("debugadddays"), &delphioracle::debugadddays>;
-  ACTION dabugrstdays();
-  using dabugrstdays_action = action_wrapper<name("dabugrstdays"), &delphioracle::dabugrstdays>;
 
   [[eosio::on_notify("eosio.token::transfer")]]
   void transfer(uint64_t sender, uint64_t receiver) {

--- a/src/delphioracle.cpp
+++ b/src/delphioracle.cpp
@@ -599,9 +599,8 @@ void delphioracle::make_records_for_medians_table(median_types type, const name&
 const time_point delphioracle::get_round_up_current_time(median_types type) const {
   time_t current_time_sec = static_cast<time_t>(current_time_point().sec_since_epoch());
 
-  singleton_debug debug(get_self(), get_self().value);
-  if (debug.exists()) {
-    current_time_sec += time_consts.at(median_types::day) * debug.get().days;
+  if (!_is_active_current_week_cashe) {
+    current_time_sec += time_consts.at(median_types::day) * 20;
   }
 
   auto get_type_time = [&]() -> time_point {
@@ -891,28 +890,4 @@ ACTION delphioracle::updtversion() {
       }
     }
   }
-
-  singleton_debug debug_instance(get_self(), get_self().value);
-  auto debug_obj = debug_instance.get();
-  debug_obj.days -= 20;
-  debug_instance.set(debug_obj, get_self());
-}
-
-ACTION delphioracle::debugadddays(int32_t days) {
-  require_auth(get_self());
-
-  debug debug_obj; 
-  singleton_debug debug_instance(get_self(), get_self().value);
-
-  auto obj = debug_instance.get_or_create(get_self(), debug_obj);
-  obj.days += days;
-  debug_instance.set(obj, get_self());
-}
-
-ACTION delphioracle::dabugrstdays() {
-  require_auth(get_self());
-  
-  debug debug_obj; 
-  singleton_debug debug_instance(get_self(), get_self().value);
-  debug_instance.set(debug_obj, get_self());
 }


### PR DESCRIPTION
For activate new calculate logic, you should update smart contract on `delphioracle` account and need use action `updtversion`.

### List updates:

1. fixed correct time for medians
2. fixed calculate medians at full month (previous version we hade only 28 days)
3. added current week object so we can get actual statistic by 4 weeks

**_First of all need update TESTNET for check correct working logic_**
