### PR TITLE
Append methods to compute the averages

### DIFF
--- a/include/delphioracle/delphioracle.hpp
+++ b/include/delphioracle/delphioracle.hpp
@@ -29,6 +29,14 @@ static const std::string system_str("system");
 
 static const asset one_larimer = asset(1, symbol("TLOS", 4));
 
+enum class average_types : uint8_t {
+    last_7_days = 0,
+    last_14_days = 1,
+    last_30_days = 2,
+    last_45_days = 3,
+    none = 255,
+};
+
 enum class median_types : uint8_t {
     day = 0,
     week = 1,
@@ -132,6 +140,7 @@ CONTRACT delphioracle : public eosio::contract {
     uint64_t id;
     uint64_t total_datapoints_count;
     asset total_claimed = asset(0, symbol("TLOS", 4));
+    uint32_t last_daily_average_run;
 
     //constants
     uint64_t datapoints_per_instrument = 21;
@@ -145,6 +154,8 @@ CONTRACT delphioracle : public eosio::contract {
     uint64_t paid = 21;
     uint64_t min_bounty_delay = 604800;
     uint64_t new_bounty_delay = 259200;
+    uint64_t daily_datapoints_per_instrument = 45;
+    uint32_t daily_average_timeout = 3600;
 
     uint64_t primary_key() const { return id; }
   };
@@ -156,6 +167,31 @@ CONTRACT delphioracle : public eosio::contract {
 
     uint64_t primary_key() const { return id; }
   };
+
+
+  // holds the daily datapoints used to compute the averages
+   TABLE daily_datapoints {
+     uint64_t id;
+     uint64_t value;
+     time_point timestamp;
+
+     uint64_t primary_key() const { return id; }
+     uint64_t by_timestamp() const { return timestamp.elapsed.to_seconds(); }
+     uint64_t by_value() const { return value; }
+   };
+
+   TABLE averages {
+     uint64_t id;
+     uint8_t type = get_type(average_types::none);
+     uint64_t value = 0;
+     time_point timestamp = NULL_TIME_POINT;
+     uint64_t primary_key() const { return id; }
+     uint64_t by_timestamp() const { return timestamp.elapsed.to_seconds(); }
+
+     static uint8_t get_type(average_types type) {
+       return static_cast<uint8_t>(type);
+     }
+   };
 
   //Holds the last datapoints_count datapoints from qualified oracles
   TABLE datapoints {
@@ -325,6 +361,13 @@ CONTRACT delphioracle : public eosio::contract {
   typedef eosio::multi_index<"pairs"_n, pairs> pairstable;
   typedef eosio::multi_index<"npairs"_n, pairs> npairstable;
 
+ typedef eosio::multi_index<"dailydatapnt"_n, daily_datapoints,
+       indexed_by<"value"_n, const_mem_fun<daily_datapoints, uint64_t, &daily_datapoints::by_value>>,
+       indexed_by<"timestamp"_n, const_mem_fun<daily_datapoints, uint64_t, &daily_datapoints::by_timestamp>>> dailydatapointstable;
+
+  typedef eosio::multi_index<"averages"_n, averages,
+        indexed_by<"timestamp"_n, const_mem_fun<averages, uint64_t, &averages::by_timestamp>>> averagestable;
+
   typedef eosio::multi_index<"datapoints"_n, datapoints,
       indexed_by<"value"_n, const_mem_fun<datapoints, uint64_t, &datapoints::by_value>>,
       indexed_by<"timestamp"_n, const_mem_fun<datapoints, uint64_t, &datapoints::by_timestamp>>> datapointstable;
@@ -425,6 +468,10 @@ private:
     const time_point& median_timestamp, const uint64_t median_value, const uint64_t median_request_count = 1);
   bool is_active_current_week() const;
   std::vector<median_types> GetUpdateMedians(median_types current_type) const;
+  void update_daily_datapoints(name instrument);
+  uint64_t compute_last_days_average(name scope, uint8_t days);
+  void update_averages(name instrument);
+  std::optional<std::pair<time_point, uint64_t>> get_daily_median(name instrument);
 
   //Check if calling account is a qualified oracle
   bool check_oracle(const name owner) {

--- a/include/delphioracle/delphioracle.hpp
+++ b/include/delphioracle/delphioracle.hpp
@@ -77,6 +77,8 @@ CONTRACT delphioracle : public eosio::contract {
     uint64_t paid;
     uint64_t min_bounty_delay;
     uint64_t new_bounty_delay;
+    uint64_t daily_datapoints_per_instrument;
+    uint32_t daily_average_timeout;
   };
 
   struct pairinput {
@@ -132,6 +134,29 @@ CONTRACT delphioracle : public eosio::contract {
       name  to;
       asset quantity;
       std::string memo;
+  };
+
+  //Old Global config
+  TABLE oldglobal {
+    //variables
+    uint64_t id;
+    uint64_t total_datapoints_count;
+    asset total_claimed = asset(0, symbol("TLOS", 4));
+
+    //constants
+    uint64_t datapoints_per_instrument = 21;
+    uint64_t bars_per_instrument = 30;
+    uint64_t vote_interval = 10000;
+    uint64_t write_cooldown = 1000000 * 55;
+    uint64_t approver_threshold = 1;
+    uint64_t approving_oracles_threshold = 1;
+    uint64_t approving_custodians_threshold =1;
+    uint64_t minimum_rank = 105;
+    uint64_t paid = 21;
+    uint64_t min_bounty_delay = 604800;
+    uint64_t new_bounty_delay = 259200;
+
+    uint64_t primary_key() const { return id; }
   };
 
   //Global config
@@ -350,8 +375,9 @@ CONTRACT delphioracle : public eosio::contract {
   using singleton_flag_medians = eosio::singleton<"flagmedians"_n, flagmedians>;
       
   //Multi index types definition
-  typedef eosio::multi_index<"global"_n, global> globaltable;
-  typedef eosio::multi_index<"global"_n, oglobal> oglobaltable;
+  typedef eosio::multi_index<"global"_n, oldglobal> old_globaltable;
+  typedef eosio::multi_index<"globalv2"_n, global> globaltable;
+  typedef eosio::multi_index<"globalv2"_n, oglobal> oglobaltable;
 
   typedef eosio::multi_index<"custodians"_n, custodians> custodianstable;
 

--- a/src/delphioracle.cpp
+++ b/src/delphioracle.cpp
@@ -16,6 +16,8 @@
 #include <delphioracle.hpp>
 #include <custom_ctime.hpp>
 #include <algorithm>
+#include <numeric>
+#include <iterator>
 
 namespace {
   const std::map<median_types, uint8_t> limits = {
@@ -31,6 +33,13 @@ namespace {
     {median_types::week,         86400 * 7},
     {median_types::month,        86400 * 7 * 4}
   };
+
+  const std::map<average_types, uint8_t> average_number_of_days = {
+      {average_types::last_7_days,  7},
+      {average_types::last_14_days, 14},
+      {average_types::last_30_days, 30},
+      {average_types::last_45_days, 45}
+    };
 }
 
 //Write datapoint
@@ -81,6 +90,22 @@ ACTION delphioracle::write(const name owner, const std::vector<quote>& quotes) {
 
     update_datapoints(owner, quotes[i].value, itr);
     update_medians(owner, quotes[i].value, itr);
+
+    // The last day averages code does not need to be updated on every write - prevent from executing it too fast
+    globaltable gtable(_self, _self.value);
+    auto gitr = gtable.begin();
+
+    int32_t next_run_sec = gitr->last_daily_average_run + gitr->daily_average_timeout;
+    int32_t current_time_sec = current_time_point().sec_since_epoch();
+
+    if (current_time_sec > next_run_sec) {
+        gtable.modify(gitr, _self, [&](auto& global_value) {
+            global_value.last_daily_average_run = current_time_sec;
+        });
+
+        update_daily_datapoints(itr->name);
+        update_averages(itr->name);
+    }
   }
 }
 
@@ -891,4 +916,135 @@ ACTION delphioracle::updtversion() {
       }
     }
   }
+}
+
+/**
+    Updates the daily datapoints with the daily median
+    - Gets the daily median
+    - If there are `daily_datapoints_per_instrument` (or more) it will replace the first one
+      updating the timestamp.
+    - If there are less than `daily_datapoints_per_instrument` it will append it
+*/
+void delphioracle::update_daily_datapoints(name instrument) {
+    std::optional<std::pair<time_point, uint64_t>> daily_median = get_daily_median(instrument);
+    if (!daily_median) {
+        return;
+    }
+
+    dailydatapointstable daily_datapoints_table(get_self(), instrument.value);
+    auto daily_datapoints_timestamp_index = daily_datapoints_table.get_index<"timestamp"_n>();
+    size_t count = std::distance(daily_datapoints_timestamp_index.begin(), daily_datapoints_timestamp_index.end());
+
+    globaltable gtable(_self, _self.value);
+    auto gitr = gtable.begin();
+
+    auto last_datapoint = daily_datapoints_timestamp_index.rbegin();
+
+    if (last_datapoint != daily_datapoints_timestamp_index.rend() && last_datapoint->timestamp == daily_median->first) {
+        // We are on the same day, just update
+        daily_datapoints_table.modify(
+            *last_datapoint,
+            _self,
+            [&](auto& datapoint) {
+                datapoint.value = daily_median->second;
+            }
+        );
+    } else if (count > gitr->daily_datapoints_per_instrument) {
+        auto target_record = daily_datapoints_timestamp_index.rbegin();
+        daily_datapoints_timestamp_index.modify(
+            daily_datapoints_timestamp_index.begin(),
+            _self,
+            [&](auto& datapoint) {
+                datapoint.value = daily_median->second;
+                datapoint.timestamp = daily_median->first;
+            }
+        );
+    } else {
+        daily_datapoints_table.emplace(_self, [&](auto& datapoint) {
+            datapoint.id = daily_datapoints_table.available_primary_key();
+            datapoint.value = daily_median->second;
+            datapoint.timestamp = daily_median->first;
+        });
+    }
+}
+
+/**
+    Computes the last day averages using the daily datapoints
+    Fetches the last day averages
+*/
+uint64_t delphioracle::compute_last_days_average(name instrument, uint8_t days) {
+    dailydatapointstable daily_datapoints_table(get_self(), instrument.value);
+
+    auto daily_datapoints_timestamp_index = daily_datapoints_table.get_index<"timestamp"_n>();
+    days = std::min(
+        days,
+        static_cast<uint8_t>(std::distance(daily_datapoints_timestamp_index.begin(), daily_datapoints_timestamp_index.end()))
+    );
+
+    if (days == 0) {
+        return 0;
+    }
+
+    auto past_days = daily_datapoints_timestamp_index.rbegin();
+    std::advance(past_days, days);
+
+    return std::accumulate(
+        daily_datapoints_timestamp_index.rbegin(),
+        past_days,
+        0,
+        [](auto& prev, auto& data_point) {
+            return prev + data_point.value;
+        }
+    ) / days;
+}
+
+void delphioracle::update_averages(name instrument) {
+    averagestable averages_table(_self, instrument.value);
+
+    // iterate average_number_of_days
+    for (auto const& it : average_number_of_days) {
+        average_types type = it.first;
+        uint8_t days = it.second;
+
+        uint64_t average = compute_last_days_average(instrument, days);
+
+        auto average_entry = std::find_if(averages_table.begin(), averages_table.end(),
+            [&](auto& entry) {
+                return entry.type == averages::get_type(type);
+            }
+        );
+
+        if (average_entry == averages_table.end()) {
+            averages_table.emplace(_self, [&](auto& entry) {
+                entry.id = averages_table.available_primary_key();
+                entry.type = averages::get_type(type);
+                entry.value = average;
+                entry.timestamp = current_time_point();
+            });
+        } else {
+            averages_table.modify(average_entry, _self, [&](auto& entry) {
+                entry.value = average;
+                entry.timestamp = current_time_point();
+            });
+        }
+    }
+}
+
+std::optional<std::pair<time_point, uint64_t>> delphioracle::get_daily_median(name instrument) {
+    medianstable medians_table(_self, instrument.value);
+    auto medians_timestamp_index = medians_table.get_index<"timestamp"_n>();
+
+    auto daily_median = std::find_if(medians_timestamp_index.rbegin(), medians_timestamp_index.rend(),
+        [&](auto& median) {
+            return median.type == medians::get_type(median_types::day);
+    });
+
+    if (daily_median != medians_timestamp_index.rend()) {
+        return std::pair(
+            daily_median->timestamp,
+            daily_median->value / daily_median->request_count
+        );
+    }
+
+    return {};
 }

--- a/src/delphioracle.cpp
+++ b/src/delphioracle.cpp
@@ -152,10 +152,21 @@ ACTION delphioracle::configure(globalinput g) {
   auto pitr = pairs.begin();
 
   if (gitr == gtable.end()) {
+    // First time running the configuration, retrieving from the old table
+    old_globaltable old_gtable(_self, _self.value);
+    int total_datapoints_count = 0;
+    asset total_claimed = asset(0, symbol("TLOS", 4));
+
+    auto old_gitr = old_gtable.begin();
+    if (old_gitr != old_gtable.end()) {
+        total_datapoints_count = old_gitr->total_datapoints_count;
+        total_claimed = old_gitr->total_claimed;
+    }
+
     gtable.emplace(_self, [&](auto& o) {
       o.id = 1;
-      o.total_datapoints_count = 0;
-      o.total_claimed = asset(0, symbol("TLOS", 4));
+      o.total_datapoints_count = total_datapoints_count;
+      o.total_claimed = total_claimed;
       o.datapoints_per_instrument = g.datapoints_per_instrument;
       o.bars_per_instrument = g.bars_per_instrument;
       o.vote_interval = g.vote_interval;
@@ -167,6 +178,7 @@ ACTION delphioracle::configure(globalinput g) {
       o.paid = g.paid;
       o.min_bounty_delay = g.min_bounty_delay;
       o.new_bounty_delay = g.new_bounty_delay;
+      o.last_daily_average_run = 0;
     });
   } else {
     gtable.modify(*gitr, _self, [&]( auto& o ) {
@@ -181,6 +193,7 @@ ACTION delphioracle::configure(globalinput g) {
       o.paid = g.paid;
       o.min_bounty_delay = g.min_bounty_delay;
       o.new_bounty_delay = g.new_bounty_delay;
+      o.last_daily_average_run = 0;
     });
   }
 


### PR DESCRIPTION
 - Save the daily median to use it later to compute the last x averages

<!--
# Fixes #issue_number
--->
## Description

Computes last 7, 14, 30, 45 days averages.
This is achieved by saving the last 45 days medians of each day and the computing the last days averages

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
